### PR TITLE
Fix OUYA CONTROLLER axis mappings on Unity 4.2 & below.

### DIFF
--- a/Assets/Plugins/OuyaExampleCommon.cs
+++ b/Assets/Plugins/OuyaExampleCommon.cs
@@ -292,17 +292,17 @@ public class OuyaExampleCommon
                         invert = true;
                         break;
                     case OuyaSDK.KeyEnum.AXIS_RSTICK_X:
-                        axisName = string.Format("Joy{0} Axis 4", (int)player);
+                        axisName = string.Format("Joy{0} Axis 3", (int)player);
                         invert = true;
                         break;
                     case OuyaSDK.KeyEnum.AXIS_RSTICK_Y:
-                        axisName = string.Format("Joy{0} Axis 5", (int)player);
+                        axisName = string.Format("Joy{0} Axis 4", (int)player);
                         break;
                     case OuyaSDK.KeyEnum.BUTTON_LT:
-                        axisName = string.Format("Joy{0} Axis 9", (int)player);
+                        axisName = string.Format("Joy{0} Axis 5", (int)player);
                         break;
                     case OuyaSDK.KeyEnum.BUTTON_RT:
-                        axisName = string.Format("Joy{0} Axis 10", (int)player);
+                        axisName = string.Format("Joy{0} Axis 6", (int)player);
                         break;
                     default:
                         return 0f;


### PR DESCRIPTION
These are correct right stick and trigger mappings under Unity 4.2.2, as tested with SceneShowUnityInput. Maybe they got messed up in the process of adding all the conditional compiles for Unity 4.3.x ?
