### PR TITLE
Updated java JDK download paths

### DIFF
--- a/Assets/Ouya/SDK/Editor/OuyaPanel.cs
+++ b/Assets/Ouya/SDK/Editor/OuyaPanel.cs
@@ -1549,9 +1549,9 @@ public class OuyaPanel : EditorWindow
     {
         EditorBuildSettings.scenes = scenes;
         m_nextScene = scenes[0].path;
-		
-		apkName = string.Format ("{0}.apk", productName);
-		EditorPrefs.SetString(KEY_APK_NAME, apkName);
+        
+        apkName = string.Format ("{0}.apk", productName);
+        EditorPrefs.SetString(KEY_APK_NAME, apkName);
 
         PlayerSettings.bundleIdentifier = string.Format("tv.ouya.demo.{0}", productName);
         PlayerSettings.productName = productName;
@@ -1959,22 +1959,22 @@ public class OuyaPanel : EditorWindow
 
                 GUILayout.EndHorizontal();
 
-				GUILayout.Label("Java JDK Download Links (32bit)", EditorStyles.boldLabel);	
+                GUILayout.Label("Java JDK Download Links (32bit)", EditorStyles.boldLabel); 
 
                 if (GUILayout.Button("Windows XP, Vista, 7"))
                 {
                     Application.OpenURL("http://www.oracle.com/technetwork/java/javasebusiness/downloads/java-archive-downloads-javase6-419409.html#jdk-6u45-oth-JPR");
                 }
 
-				if (GUILayout.Button("Windows 8"))
-				{
-					Application.OpenURL("http://www.oracle.com/technetwork/java/javase/downloads/jdk7-downloads-1880260.html");
-				}
+                if (GUILayout.Button("Windows 8"))
+                {
+                    Application.OpenURL("http://www.oracle.com/technetwork/java/javase/downloads/jdk7-downloads-1880260.html");
+                }
 
-				if (GUILayout.Button("OSX"))
-				{
-					Application.OpenURL("http://support.apple.com/kb/DL1572?viewlocale=en_US");
-				}
+                if (GUILayout.Button("OSX"))
+                {
+                    Application.OpenURL("http://support.apple.com/kb/DL1572?viewlocale=en_US");
+                }
 
                 break;
             case 3:

--- a/Assets/Ouya/SDK/Editor/OuyaPanel.cs
+++ b/Assets/Ouya/SDK/Editor/OuyaPanel.cs
@@ -1959,10 +1959,22 @@ public class OuyaPanel : EditorWindow
 
                 GUILayout.EndHorizontal();
 
-                if (GUILayout.Button("Download JDK 6 32-bit"))
+				GUILayout.Label("Java JDK Download Links (32bit)", EditorStyles.boldLabel);	
+
+                if (GUILayout.Button("Windows XP, Vista, 7"))
                 {
                     Application.OpenURL("http://www.oracle.com/technetwork/java/javasebusiness/downloads/java-archive-downloads-javase6-419409.html#jdk-6u45-oth-JPR");
                 }
+
+				if (GUILayout.Button("Windows 8"))
+				{
+					Application.OpenURL("http://www.oracle.com/technetwork/java/javase/downloads/jdk7-downloads-1880260.html");
+				}
+
+				if (GUILayout.Button("OSX"))
+				{
+					Application.OpenURL("http://support.apple.com/kb/DL1572?viewlocale=en_US");
+				}
 
                 break;
             case 3:


### PR DESCRIPTION
Added a label for download links and made buttons for different operating systems. Monodevelop messed up the indentation. I have tested all download links on Windows 7, 8 and OSX 10.9 they work and compile properly.
